### PR TITLE
Various improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,26 @@
-# LazerToStable
+# Lazer 2 Stable
 
-A working converter from file format v128 (current lazer) to file format v14 (stable). Place your .osu file(s) you want to convert into the folder with README.md, and run with
-```
-python -m src.main
-```
-on the command line from the folder containing the README.
+Convert osu!lazer beatmaps to a format compatible with legacy version of the game (v128 -> v14).
+
+## Requirements
+* Python 3 (tested with v3.10.6, but )
+* numpy
+
+## Usage
+0. If you don't have numpy installed, run this command:
+    ```commandline
+    pip install numpy
+    ```
+1. Clone the repository.
+    ```commandline
+    git clone https://github.com/ekgame/lazer-2-stable.git
+    ```
+2. Run the script
+    ```commandline
+    cd lazer-2-stable
+    python convert.py <path to file>
+    ```
+
+The file may be either a plaintext .osu beatmap file or a .osz mapset archive. For .osz archives - all the .osu files inside will be converted and the other files are copied verbatim.
+
+The original file will be copied as a backup and replaced with the converted version.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Convert osu!lazer beatmaps to a format compatible with legacy version of the game (v128 -> v14).
 
 ## Requirements
-* Python 3 (tested with v3.10.6, but )
+* Python 3 (tested with v3.10.6)
 * numpy
 
 ## Usage

--- a/convert.py
+++ b/convert.py
@@ -1,0 +1,101 @@
+from copy import deepcopy
+from src.osu import parse_osu_file_from_string, OsuFile
+import numpy
+from src.main import zeroFloor, clamp, processSlider
+import argparse
+import pathlib
+import shutil
+import zipfile
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert osu!lazer beatmaps to a format compatible with legacy version of the game.",
+        usage="python convert.py <file>",
+    )
+    parser.add_argument('file', help="The file to convert, .osu or .osz file.")
+    args = parser.parse_args()
+    file = pathlib.Path(args.file)
+
+    if not file.exists():
+        print('File does not exist.')
+        return
+
+    if file.suffix.lower() == '.osu':
+        convert_single_file(file)
+    elif file.suffix.lower() == '.osz':
+        convert_package(file)
+    else:
+        print('can only handle .osu and .osz files.')
+
+
+def convert_single_file(path):
+    original_path = pathlib.PurePath(path)
+    backup_path = pathlib.PurePath(path).with_name(original_path.name + ".backup")
+
+    file = path.open(encoding='utf8')
+    osu_file = parse_osu_file_from_string(file.read())
+    file.close()
+
+    shutil.move(str(original_path), str(backup_path))
+
+    converted_osu_file = process_osu_file(osu_file)
+    pathlib.Path(original_path).write_text(converted_osu_file.to_string())
+
+
+def convert_package(path):
+    original_path = pathlib.PurePath(path)
+    backup_path = pathlib.PurePath(path).with_name(original_path.name + ".backup")
+
+    shutil.move(str(original_path), str(backup_path))
+
+    with zipfile.ZipFile(str(backup_path)) as zip_in, zipfile.ZipFile(str(original_path), "w") as zip_out:
+        for info in zip_in.infolist():
+            with zip_in.open(info) as file:
+                if info.filename.lower().endswith(".osu"):
+                    osu_file = parse_osu_file_from_string(file.read().decode("utf-8"))
+                    converted_osu_file = process_osu_file(osu_file)
+                    zip_out.writestr(info.filename, converted_osu_file.to_string())
+                else:
+                    zip_out.writestr(info.filename, file.read())
+
+
+def process_osu_file(osu_file: OsuFile) -> OsuFile:
+    new_sections = deepcopy(osu_file.sections)
+    new_sections['TimingPoints'] = map(process_timing_point_line, osu_file.sections['TimingPoints'])
+    new_sections['HitObjects'] = map(lambda line: process_hit_object_line(line, osu_file.version), osu_file.sections['HitObjects'])
+    return OsuFile('14', new_sections)
+
+
+def process_timing_point_line(line: str) -> str:
+    parts = line.split(",")
+    return "%d,%s" % (int(numpy.floor(float(parts[0]))),",".join(parts[1:]))
+
+
+def process_hit_object_line(line: str, format_version: str) -> str:
+    parts = line.split(",")
+    object_type = int(parts[3])
+    if not (object_type & 2):
+        # not a slider, do not convert
+        return line
+
+    x = zeroFloor(clamp(float(parts[0]), 131072))
+    y = zeroFloor(clamp(float(parts[1]), 131072))
+    timestamp = int(numpy.floor(float(parts[2])))
+    hit_sound = clamp(int(parts[4]), 131072)
+    path = parts[5]
+    repeats = clamp(int(parts[6]), 131072)
+    length = None
+    if len(parts) > 7:
+        length = max((0, clamp(float(parts[7]), 131072)))
+        if length == 0:
+            length = None
+    rest = ",".join(parts[8:])
+
+    # most of the magic happens here
+    new_path = processSlider(x, y, path, format_version)
+    return ','.join(map(str, [x, y, timestamp, object_type, hit_sound, new_path, repeats, length, rest]))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/osu.py
+++ b/src/osu.py
@@ -1,0 +1,53 @@
+from typing import Dict, List
+import re
+
+
+class OsuFile:
+    def __init__(self, version: str, sections: Dict[str, List[str]]):
+        self.version = version
+        self.sections = sections
+
+    def to_string(self) -> str:
+        result = "osu file format v" + self.version + "\n\n"
+
+        for section, lines in self.sections.items():
+            result += "[" + section + "]\n"
+            result += "\n".join(lines) + "\n\n"
+
+        return result
+
+
+def parse_osu_file_from_string(source: str) -> OsuFile:
+    sections: Dict[str, List[str]] = {}
+    version = None
+    current_part = None
+
+    for line in source.splitlines():
+        version_match = re.search('osu file format v(\\d+)\n?$', line)
+        if version_match:
+            version = version_match.group(1)
+            continue
+
+        header_match = re.search('^\[(\\w+)\]\n?$', line)
+        if header_match:
+            current_part = header_match.group(1)
+            continue
+
+        if line.strip() == '' or current_part is None:
+            continue
+
+        sections.setdefault(current_part, []).append(line)
+
+    if version is None:
+        raise Exception("Could not parse osu format version")
+
+    if len(sections.keys()) == 0:
+        raise Exception("Could not parse any sections from the osu format")
+
+    if 'HitObjects' not in sections:
+        raise Exception("Missing HitObjects section")
+
+    if 'TimingPoints' not in sections:
+        raise Exception("Missing TimingPoints section")
+
+    return OsuFile(version, sections)


### PR DESCRIPTION
This pull request implements various improvements to the converter:
1. Requires to specify a file to convert instead of converting all the files in the directory. The file may even be outside of the directory.
2. Converts both .osu and .osz files.
3. Instead of creating a file with new name and version - create a backup and override the file.
4. Replaced .osu file-to-file transformation with a more robust system:
   - Decode the file into sections with lines
   - Modify "HitObjects" and "TimingPoints" sections
   - Re-encode the file
5. Do not convert 1-span sliders to bezier paths - fixes an issue where simple arcs would get converted to beziers even though they are perfectly valid in v14.
6. Updated README.